### PR TITLE
Update libtiff datatype reference

### DIFF
--- a/libtiff/tiff.go
+++ b/libtiff/tiff.go
@@ -52,7 +52,7 @@ func (t Tiff) Iter(cb func(int)) int {
 }
 
 func (t Tiff) SetDir(n int) error {
-	if int(C.TIFFSetDirectory(t.data, C.uint16(n))) != 1 {
+	if int(C.TIFFSetDirectory(t.data, C.tdir_t(n))) != 1 {
 		return errors.New("Invalid directory")
 	}
 	return nil


### PR DESCRIPTION
Updates this wrapper to use a libtiff-provided typedef tdir_t instead of uint_16.

Libtiff 4.5 introduced a [breaking change](https://libtiff.gitlab.io/libtiff/releases/v4.5.0.html) for this type that affects TIFFSetDirectory. We ran into this when trying to upgrade to a newer Debian base image for the personal deploy build, and it will likely affect upcoming Ubuntu upgrades as well. 

Plan is to at least temporarily vendor this dependency, while we push a PR to the upstream. 